### PR TITLE
📝 Remove a mention of .hpp to replace it with .h

### DIFF
--- a/docs/docs/contributing/cpp-naming-conventions.md
+++ b/docs/docs/contributing/cpp-naming-conventions.md
@@ -14,7 +14,7 @@ ecs/registry.h
 
 ### 1.1 C++ files extensions
 
-**.cpp** for source & **.hpp** for headers.
+**.cpp** for source & **.h** for headers.
 
 ```sh
 main.cpp


### PR DESCRIPTION
## Summary
Remove mentions of .hpp and replace them to .h in the docs

## Related Issue(s)
- None :)


## Additions
- Fix wrong extension usage in the docs (.hpp => .h).

## Testing
1. Read the docs

## Checklist
- [x] Source branch is based on `dev`
- [x] Linked to the correct GitHub issues
- [x] Added at least 2 people as reviewers, 4 if you are merging into main
- [x] No conflicts
- [x] Documentation deployment CI must pass
