### PR TITLE
💚 Fix docusaurus previews

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -2,7 +2,7 @@ import {themes as prismThemes} from 'prism-react-renderer';
 import type {Config} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 
-const baseUrl = process.env.BASE_URL || '/whanos/';  // Used to make previews
+const baseUrl = process.env.BASE_URL || '/R-Type/';  // Used to make previews
 
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 


### PR DESCRIPTION
## Summary
Make docusaurus use the correct base path on previews of the documentation.
It fetches the base path from the env var `BASE_URL`.

## Related Issue(s)
- None

## Root Cause & Solution
When looking at previews, the base adress will not be `/` but `/branch_name/`.
The problem is that docusaurus needs to know the base path for it's router to work properly.
So the CI injects the env var directly when starting the docs.

## Testing
1. Click on the documentation preview link under this PR, everything should work fine.

## Checklist
- [x] Source branch is based on `dev`
- [x] Linked to the correct GitHub issues
- [x] Added at least 2 people as reviewers, 4 if you are merging into main
- [x] No conflicts
- [x] Documentation deployment CI must pass
