### PR TITLE
💚 Fix typo in the deploy-docusaurus.yaml

### DIFF
--- a/.github/workflows/deploy-docusaurus.yaml
+++ b/.github/workflows/deploy-docusaurus.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Build docs
         run: |
-          export BASE_URL="/R-type/"
+          export BASE_URL="/R-Type/"
           npm run build
 
       - name: Deploy production docs


### PR DESCRIPTION
## Summary
Fix typo in docusaurus deploy workflow.

## Related Issue(s)
- None


## Root Cause & Solution
`R-type` => `R-Type`

## Testing
1. Try to access the default doc once this PR will be merged

## Checklist
- [x] Source branch is based on `dev`
- [x] Linked to the correct GitHub issues
- [x] Added at least 2 people as reviewers, 4 if you are merging into main
- [x] No conflicts
- [x] Documentation deployment CI must pass
