### PR TITLE
✨ Add Windows build support and update README with installation instructions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,7 +5,7 @@ on:
     branches: [ main, dev ]
 
 jobs:
-  build:
+  build-linux:
     strategy:
       matrix:
         build_type: [Debug, Release]
@@ -34,7 +34,7 @@ jobs:
         restore-keys: |
           linux-cpm-
 
-    - name: Cache CMake build
+    - name: Cache CMake build (Linux)
       uses: actions/cache@v4
       with:
         path: |
@@ -82,8 +82,73 @@ jobs:
           build/bin/${{ matrix.build_type }}/r-type_client
           build/bin/${{ matrix.build_type }}/r-type_server
 
-  test:
-    needs: build
+  build-windows:
+    strategy:
+      matrix:
+        build_type: [Debug, Release]
+
+    runs-on: windows-latest
+    timeout-minutes: 45
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup MSYS2 with MinGW-w64
+      uses: msys2/setup-msys2@v2
+      with:
+        update: false
+        install: >-
+          mingw-w64-x86_64-toolchain
+          mingw-w64-x86_64-cmake
+          mingw-w64-x86_64-make
+          mingw-w64-x86_64-ninja
+
+    - name: Cache CPM dependencies
+      uses: actions/cache@v4
+      with:
+        path: |
+          build/_deps
+          ~/.cache/CPM
+        key: windows-cpm-${{ hashFiles('CMakeLists.txt', 'src/**/CMakeLists.txt') }}
+        restore-keys: |
+          windows-cpm-
+
+    - name: Cache CMake build (Windows)
+      uses: actions/cache@v4
+      with:
+        path: |
+          build
+        key: windows-build-${{ matrix.build_type }}-${{ hashFiles('CMakeLists.txt', 'src/**/*') }}
+        restore-keys: |
+          windows-build-${{ matrix.build_type }}-
+          windows-build-
+
+    - name: Configure CMake (MinGW Makefiles)
+      shell: msys2 {0}
+      run: |
+        mkdir -p build
+        cd build
+        cmake .. -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+          -DCPM_SOURCE_CACHE=$HOME/.cache/CPM \
+          -DCMAKE_VERBOSE_MAKEFILE=OFF
+
+    - name: Build project
+      shell: msys2 {0}
+      run: |
+        cd build
+        cmake --build . --parallel 2
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: r-type-windows-${{ matrix.build_type }}
+        path: |
+          build/bin/${{ matrix.build_type }}/r-type_client.exe
+          build/bin/${{ matrix.build_type }}/r-type_server.exe
+
+  test-linux:
+    needs: build-linux
     strategy:
       matrix:
         build_type: [Debug, Release]
@@ -109,5 +174,35 @@ jobs:
       run: |
         ls -la ./artifacts/
 
-    # Add more specific tests here as needed
-    # For example, you could run unit tests or basic functionality tests
+  test-windows:
+    needs: build-windows
+    strategy:
+      matrix:
+        build_type: [Debug, Release]
+
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: r-type-windows-${{ matrix.build_type }}
+        path: ./artifacts
+
+    - name: Test executables exist
+      shell: pwsh
+      run: |
+        Get-ChildItem -Path ./artifacts
+
+    - name: Smoke test server -- help
+      shell: pwsh
+      run: |
+        Start-Process -FilePath ./artifacts/r-type_server.exe -ArgumentList '--help' -NoNewWindow -PassThru | Wait-Process
+    
+    - name: Smoke test client -- help
+      shell: pwsh
+      run: |
+        Start-Process -FilePath ./artifacts/r-type_client.exe -ArgumentList '--help' -NoNewWindow -PassThru | Wait-Process

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,17 @@ if(asio_ADDED)
     add_library(asio INTERFACE)
     target_include_directories(asio INTERFACE ${asio_SOURCE_DIR}/asio/include)
     target_compile_definitions(asio INTERFACE ASIO_STANDALONE)
+    
+    # Windows-specific settings
+    if(WIN32)
+        target_compile_definitions(asio INTERFACE 
+            _WIN32_WINNT=0x0601  # Windows 7 or later
+            NOGDI                 # Prevents Windows GDI conflicts with raylib
+            NOUSER                # Prevents Windows USER conflicts with raylib
+        )
+        target_link_libraries(asio INTERFACE ws2_32)
+    endif()
+    
     find_package(Threads REQUIRED)
     target_link_libraries(asio INTERFACE Threads::Threads)
 endif()

--- a/README.md
+++ b/README.md
@@ -54,4 +54,76 @@ r-type_server -p 8080
 
 ### Windows
 
-Not done wet :)
+#### Prerequisites
+
+1. **MinGW-w64 (W64Devkit)** - Download from [W64Devkit releases](https://github.com/skeeto/w64devkit/releases)
+   - Extract W64Devkit to a directory (e.g., `C:\w64devkit`)
+   - Add the `bin` folder to your PATH (e.g., `C:\w64devkit\bin`)
+
+2. **CMake** - Download from [cmake.org](https://cmake.org/download/)
+   - Make sure CMake is added to your PATH during installation
+
+3. **Git** (optional but recommended) - For cloning the repository
+
+#### Verify Installation
+
+Open a terminal (Command Prompt, PowerShell, or W64Devkit shell) and run:
+
+```bash
+gcc --version
+cmake --version
+```
+
+Both commands should display version information if installed correctly.
+
+#### Build
+
+You have two options to build the project:
+
+**Option 1: Using the batch script (Command Prompt/PowerShell)**
+
+```cmd
+scripts\build_windows.bat
+```
+
+**Option 2: Using the bash script (Git Bash/W64Devkit shell)**
+
+```bash
+./scripts/build_windows.sh
+```
+
+The script will:
+- Check for MinGW-w64 and CMake
+- Configure the project with CMake
+- Ask you to choose between Debug or Release build
+- Build the project
+- Copy executables to the root directory
+- Optionally launch the client and server
+
+Once the script has run, you should find both executables at the root of your project:
+- `r-type_client.exe`
+- `r-type_server.exe`
+
+If not, they will be in `build\bin\Debug\` or `build\bin\Release\` depending on your build type.
+
+#### Run
+
+```cmd
+# Launch the server
+r-type_server.exe -p 8080
+```
+
+```cmd
+# Launch the client (in another terminal)
+r-type_client.exe
+```
+
+#### Troubleshooting
+
+- **"gcc not found"**: Make sure MinGW-w64's bin directory is in your PATH
+- **"cmake not found"**: Make sure CMake is installed and in your PATH
+- **Build errors**: Try cleaning the build directory and rebuilding:
+  ```cmd
+  rmdir /s /q build
+  scripts\build_windows.bat
+  ```

--- a/scripts/build_windows.bat
+++ b/scripts/build_windows.bat
@@ -1,0 +1,109 @@
+@echo off
+REM Standalone Windows build script - configures and builds the project using CMake with MinGW-w64
+REM Prerequisites: MinGW-w64 (W64Devkit) must be installed and in PATH
+
+setlocal EnableDelayedExpansion
+
+REM Color setup for Windows
+set "BLUE=[1;34m"
+set "GREEN=[1;32m"
+set "YELLOW=[1;33m"
+set "RED=[1;31m"
+set "RESET=[0m"
+
+echo %BLUE%Starting Windows build script%RESET%
+
+REM Check if MinGW-w64 is available
+where gcc >nul 2>nul
+if %ERRORLEVEL% NEQ 0 (
+    echo %RED%Error: MinGW-w64 not found in PATH.%RESET%
+    echo %RED%Please install W64Devkit or MinGW-w64 and add it to your PATH.%RESET%
+    echo %YELLOW%Download W64Devkit from: https://github.com/skeeto/w64devkit/releases%RESET%
+    pause
+    exit /b 1
+)
+
+REM Check if CMake is available
+where cmake >nul 2>nul
+if %ERRORLEVEL% NEQ 0 (
+    echo %RED%Error: CMake not found in PATH.%RESET%
+    echo %RED%Please install CMake and add it to your PATH.%RESET%
+    pause
+    exit /b 1
+)
+
+REM Display versions
+for /f "tokens=*" %%i in ('gcc --version ^| findstr /r "^gcc"') do echo %GREEN%%i%RESET%
+for /f "tokens=*" %%i in ('cmake --version ^| findstr /r "^cmake"') do echo %GREEN%%i%RESET%
+
+REM Create build directory if it doesn't exist
+echo %BLUE%Setting up build directory...%RESET%
+if not exist "build" mkdir build
+cd build
+echo %GREEN%Build directory ready.%RESET%
+
+REM Prompt user for build type
+set /p build_type="%YELLOW%Build type (Release/Debug) [Debug]: %RESET%"
+if "%build_type%"=="" set build_type=Debug
+
+REM Validate build type
+if /I not "%build_type%"=="Release" if /I not "%build_type%"=="Debug" (
+    echo %RED%Invalid build type. Choose 'Release' or 'Debug'.%RESET%
+    pause
+    exit /b 1
+)
+
+REM Run CMake to configure and build the project
+echo %BLUE%Configuring project...%RESET%
+cmake .. -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=%build_type% -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+if %ERRORLEVEL% NEQ 0 (
+    echo %RED%CMake configuration failed.%RESET%
+    pause
+    exit /b 1
+)
+echo %BLUE%Building project...%RESET%
+cmake --build .
+if %ERRORLEVEL% NEQ 0 (
+    echo %RED%Build failed.%RESET%
+    pause
+    exit /b 1
+)
+echo %GREEN%Build succeeded%RESET%
+
+REM Copy binaries to parent directory
+echo %BLUE%Copying executables...%RESET%
+if exist "bin\%build_type%\r-type_client.exe" (
+    copy /Y "bin\%build_type%\r-type_client.exe" "..\r-type_client.exe" >nul
+)
+if exist "bin\%build_type%\r-type_server.exe" (
+    copy /Y "bin\%build_type%\r-type_server.exe" "..\r-type_server.exe" >nul
+)
+echo %GREEN%Executables copied to parent directory.%RESET%
+
+REM Ask user if they want to run the program
+echo %YELLOW%Do you want to run the program now ? (y/N)%RESET%
+set /p answer=
+
+if /I "%answer%"=="y" (
+    cd ..
+    echo %BLUE%Launching programs...%RESET%
+    
+    REM Launch server in new window
+    start "R-Type Server" cmd /k "echo Running %build_type% r-type_server && r-type_server.exe -p 8080"
+    
+    REM Wait a moment for server to start
+    timeout /t 2 /nobreak >nul
+    
+    REM Launch client in new window
+    start "R-Type Client" cmd /k "echo Running %build_type% r-type_client && r-type_client.exe"
+    
+    echo %GREEN%Programs launched in separate windows.%RESET%
+) else (
+    cd ..
+    echo %BLUE%Build complete. You can run the programs manually:^
+    
+        - r-type_server.exe -p 8080^
+        - r-type_client.exe%RESET%
+)
+
+pause

--- a/scripts/build_windows.sh
+++ b/scripts/build_windows.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Standalone Windows build script for MinGW/W64Devkit - configures and builds the project using CMake
+# This script works with Git Bash or W64Devkit shell on Windows
+
+set -e
+
+# Color codes for terminal output
+RED="\033[1;31m"
+GREEN="\033[1;32m"
+YELLOW="\033[1;33m"
+BLUE="\033[1;34m"
+RESET="\033[0m"
+
+# Start of the build script
+echo -e "${BLUE}Starting Windows build script (MinGW-w64)${RESET}"
+
+# Check if MinGW-w64 is available
+if ! command -v gcc &> /dev/null; then
+    echo -e "${RED}Error: MinGW-w64 not found in PATH.${RESET}"
+    echo -e "${RED}Please install W64Devkit or MinGW-w64 and add it to your PATH.${RESET}"
+    echo -e "${YELLOW}Download W64Devkit from: https://github.com/skeeto/w64devkit/releases${RESET}"
+    exit 1
+fi
+
+# Check if CMake is available
+if ! command -v cmake &> /dev/null; then
+    echo -e "${RED}Error: CMake not found in PATH.${RESET}"
+    echo -e "${RED}Please install CMake and add it to your PATH.${RESET}"
+    exit 1
+fi
+
+# Create build directory if it doesn't exist
+echo -e "${BLUE}Setting up build directory...${RESET}"
+mkdir -p build
+cd build
+echo -e "${GREEN}Build directory ready.${RESET}"
+
+# Prompt user for build type
+read -p "$(echo -e "${YELLOW}Build type (Release/Debug) [Debug]: ${RESET}")" build_type
+build_type=${build_type:-Debug}
+
+# Validate build type
+if [ "$build_type" != "Release" ] && [ "$build_type" != "Debug" ]; then
+    echo -e "${RED}Invalid build type. Choose 'Release' or 'Debug'.${RESET}"
+    exit 1
+fi
+
+# Run CMake to configure and build the project
+echo -e "${BLUE}Configuring project...${RESET}"
+cmake .. -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=$build_type -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+echo -e "${BLUE}Building project...${RESET}"
+cmake --build .
+echo -e "${GREEN}Build succeeded${RESET}"
+
+# Copy binaries to parent directory
+echo -e "${BLUE}Copying executables...${RESET}"
+if [ -f "bin/$build_type/r-type_client.exe" ]; then
+    cp bin/$build_type/r-type_client.exe ../r-type_client.exe
+fi
+if [ -f "bin/$build_type/r-type_server.exe" ]; then
+    cp bin/$build_type/r-type_server.exe ../r-type_server.exe
+fi
+echo -e "${GREEN}Executables copied to parent directory.${RESET}"
+
+# Ask user if they want to run the program
+echo -e "${YELLOW}Do you want to run the program now ? (y/N)${RESET}"
+read answer
+
+# Run the client and server in separate windows if user agreed
+if [[ "$answer" == "y" || "$answer" == "Y" ]]; then
+    cd ..
+    echo -e "${BLUE}Launching programs...${RESET}"
+    
+    # Launch server in new cmd window
+    cmd.exe /c start "R-Type Server" cmd /k "echo Running $build_type r-type_server && r-type_server.exe -p 8080"
+    
+    # Wait a moment for server to start
+    sleep 2
+    
+    # Launch client in new cmd window
+    cmd.exe /c start "R-Type Client" cmd /k "echo Running $build_type r-type_client && r-type_client.exe"
+    
+    echo -e "${GREEN}Programs launched in separate windows.${RESET}"
+else
+    cd ..
+    echo -e "${BLUE}Build complete. You can run the programs manually:"
+    echo -e "  - ./r-type_server.exe -p 8080"
+    echo -e "  - ./r-type_client.exe${RESET}"
+fi

--- a/src/game_engine/components/replicated.h
+++ b/src/game_engine/components/replicated.h
@@ -9,7 +9,7 @@ namespace engn {
 namespace cpnt {
 
 struct Replicated {
-    u_int32_t tag{};
+    uint32_t tag{};
 
     SnapshotMeta snapshot_meta;
 };


### PR DESCRIPTION
## Summary
- Added Windows build scripts (MinGW/W64Devkit) aligned with the Linux script
- CI: parallel Linux/Windows builds and tests with per-build-type artifacts

## Related Issue(s)
- N/A

## Risk & Rollback
- Low risk (CI + scripts). Rollback: restore previous workflow and build scripts.

## Testing
1. `./scripts/build_linux.sh` (Debug/Release)
2. `./scripts/build_windows.sh` (Debug/Release)
3. Check CI artifacts: `r-type-linux-*` and `r-type-windows-*`

## Checklist
- [ ] Source branch is based on `dev`
- [ ] Linked to the correct GitHub issues
- [ ] Added at least 2 reviewers (4 if merging into main)
- [ ] No conflicts
- [ ] Documentation deployment CI must pass