### PR TITLE
✨ Implement settings menu and control rebinding functionality

### DIFF
--- a/scripts/lua/ui/settings_menu.lua
+++ b/scripts/lua/ui/settings_menu.lua
@@ -1,0 +1,333 @@
+-- Define styles inline since require() is not available in this Lua environment
+local styles = {
+    main_menu = {
+        background_color =          {r = 35,  g = 35,  b = 35,  a = 255},
+        background_color_hovered =  {r = 70,  g = 70,  b = 70,  a = 255},
+        background_color_pressed =  {r = 30,  g = 30,  b = 30,  a = 255},
+        text_color =                {r = 200, g = 200, b = 200, a = 255},
+        text_color_hovered =        {r = 200, g = 200, b = 255, a = 255},
+        text_color_pressed =        {r = 150, g = 150, b = 200, a = 255},
+        border_color =              {r = 100, g = 100, b = 100, a = 255},
+        border_color_hovered =      {r = 150, g = 150, b = 150, a = 255},
+        border_color_pressed =      {r = 200, g = 200, b = 200, a = 255},
+        border_radius = 0.5,
+        border_thickness = 5
+    },
+    title = {
+        background_color =          {r = 0,  g = 0,  b = 0,  a = 0},
+        background_color_hovered =  {r = 0,  g = 0,  b = 0,  a = 0},
+        background_color_pressed =  {r = 0,  g = 0,  b = 0,  a = 0},
+        text_color =                {r = 200, g = 200, b = 200, a = 255},
+        text_color_hovered =        {r = 200, g = 200, b = 255, a = 255},
+        text_color_pressed =        {r = 150, g = 150, b = 200, a = 255},
+        border_color =              {r = 0, g = 0, b = 0, a = 0},
+        border_color_hovered =      {r = 0, g = 0, b = 0, a = 0},
+        border_color_pressed =      {r = 0, g = 0, b = 0, a = 0},
+        border_radius = 0,
+        border_thickness = 0
+    }
+}
+
+Create_ui_text(4, "settings_title", {
+    content = "Settings",
+    font_size = 80
+})
+
+Set_ui_style(4, "settings_title", styles.title)
+
+Set_ui_transform(4, "settings_title", {
+    x = 60,
+    y = 10,
+    z = 0,
+    w = 700,
+    h = 120,
+    anchor_x = 0,
+    anchor_y = 0,
+    rotation = 0
+})
+
+Create_ui_text(4, "controls_title", {
+    content = "Controls",
+    font_size = 36
+})
+
+Set_ui_style(4, "controls_title", styles.title)
+
+Set_ui_transform(4, "controls_title", {
+    x = 80,
+    y = 160,
+    z = 0,
+    w = 600,
+    h = 50,
+    anchor_x = 0,
+    anchor_y = 0,
+    rotation = 0
+})
+
+Create_ui_text(4, "mapping_move_up", {
+    content = "Move Up: W / Up",
+    font_size = 28
+})
+
+Set_ui_style(4, "mapping_move_up", styles.title)
+
+Set_ui_transform(4, "mapping_move_up", {
+    x = 100,
+    y = 230,
+    z = 0,
+    w = 520,
+    h = 40,
+    anchor_x = 0,
+    anchor_y = 0,
+    rotation = 0
+})
+
+Create_ui_button(4, "rebind_move_up")
+
+Set_ui_style(4, "rebind_move_up", styles.main_menu)
+
+Set_ui_text(4, "rebind_move_up", {
+    content = "Rebind",
+    font_size = 20
+})
+
+Set_ui_transform(4, "rebind_move_up", {
+    x = 700,
+    y = 225,
+    z = 0,
+    w = 180,
+    h = 40,
+    anchor_x = 0,
+    anchor_y = 0,
+    rotation = 0
+})
+
+Create_ui_text(4, "mapping_move_down", {
+    content = "Move Down: S / Down",
+    font_size = 28
+})
+
+Set_ui_style(4, "mapping_move_down", styles.title)
+
+Set_ui_transform(4, "mapping_move_down", {
+    x = 100,
+    y = 290,
+    z = 0,
+    w = 520,
+    h = 40,
+    anchor_x = 0,
+    anchor_y = 0,
+    rotation = 0
+})
+
+Create_ui_button(4, "rebind_move_down")
+
+Set_ui_style(4, "rebind_move_down", styles.main_menu)
+
+Set_ui_text(4, "rebind_move_down", {
+    content = "Rebind",
+    font_size = 20
+})
+
+Set_ui_transform(4, "rebind_move_down", {
+    x = 700,
+    y = 285,
+    z = 0,
+    w = 180,
+    h = 40,
+    anchor_x = 0,
+    anchor_y = 0,
+    rotation = 0
+})
+
+Create_ui_text(4, "mapping_move_left", {
+    content = "Move Left: A / Left",
+    font_size = 28
+})
+
+Set_ui_style(4, "mapping_move_left", styles.title)
+
+Set_ui_transform(4, "mapping_move_left", {
+    x = 100,
+    y = 350,
+    z = 0,
+    w = 520,
+    h = 40,
+    anchor_x = 0,
+    anchor_y = 0,
+    rotation = 0
+})
+
+Create_ui_button(4, "rebind_move_left")
+
+Set_ui_style(4, "rebind_move_left", styles.main_menu)
+
+Set_ui_text(4, "rebind_move_left", {
+    content = "Rebind",
+    font_size = 20
+})
+
+Set_ui_transform(4, "rebind_move_left", {
+    x = 700,
+    y = 345,
+    z = 0,
+    w = 180,
+    h = 40,
+    anchor_x = 0,
+    anchor_y = 0,
+    rotation = 0
+})
+
+Create_ui_text(4, "mapping_move_right", {
+    content = "Move Right: D / Right",
+    font_size = 28
+})
+
+Set_ui_style(4, "mapping_move_right", styles.title)
+
+Set_ui_transform(4, "mapping_move_right", {
+    x = 100,
+    y = 410,
+    z = 0,
+    w = 520,
+    h = 40,
+    anchor_x = 0,
+    anchor_y = 0,
+    rotation = 0
+})
+
+Create_ui_button(4, "rebind_move_right")
+
+Set_ui_style(4, "rebind_move_right", styles.main_menu)
+
+Set_ui_text(4, "rebind_move_right", {
+    content = "Rebind",
+    font_size = 20
+})
+
+Set_ui_transform(4, "rebind_move_right", {
+    x = 700,
+    y = 405,
+    z = 0,
+    w = 180,
+    h = 40,
+    anchor_x = 0,
+    anchor_y = 0,
+    rotation = 0
+})
+
+Create_ui_text(4, "mapping_shoot", {
+    content = "Shoot: Space",
+    font_size = 28
+})
+
+Set_ui_style(4, "mapping_shoot", styles.title)
+
+Set_ui_transform(4, "mapping_shoot", {
+    x = 100,
+    y = 470,
+    z = 0,
+    w = 520,
+    h = 40,
+    anchor_x = 0,
+    anchor_y = 0,
+    rotation = 0
+})
+
+Create_ui_button(4, "rebind_shoot")
+
+Set_ui_style(4, "rebind_shoot", styles.main_menu)
+
+Set_ui_text(4, "rebind_shoot", {
+    content = "Rebind",
+    font_size = 20
+})
+
+Set_ui_transform(4, "rebind_shoot", {
+    x = 700,
+    y = 465,
+    z = 0,
+    w = 180,
+    h = 40,
+    anchor_x = 0,
+    anchor_y = 0,
+    rotation = 0
+})
+
+Create_ui_text(4, "rebind_prompt", {
+    content = "Click Rebind to change controls",
+    font_size = 24
+})
+
+Set_ui_style(4, "rebind_prompt", styles.title)
+
+Set_ui_transform(4, "rebind_prompt", {
+    x = 100,
+    y = 540,
+    z = 0,
+    w = 780,
+    h = 40,
+    anchor_x = 0,
+    anchor_y = 0,
+    rotation = 0
+})
+
+Create_ui_button(4, "back_button")
+
+Set_ui_style(4, "back_button", styles.main_menu)
+
+Set_ui_text(4, "back_button", {
+    content = "Back",
+    font_size = 20
+})
+
+Set_ui_transform(4, "back_button", {
+    x = 25,
+    y = 650,
+    z = 0,
+    w = 100,
+    h = 50,
+    anchor_x = 0,
+    anchor_y = 0,
+    rotation = 0
+})
+
+Create_ui_button(4, "exit_button")
+
+Set_ui_style(4, "exit_button", styles.main_menu)
+
+Set_ui_text(4, "exit_button", {
+    content = "Exit",
+    font_size = 20
+})
+
+Set_ui_transform(4, "exit_button", {
+    x = 155,
+    y = 650,
+    z = 0,
+    w = 100,
+    h = 50,
+    anchor_x = 0,
+    anchor_y = 0,
+    rotation = 0
+})
+
+Create_ui_button(4, "main_menu_button")
+
+Set_ui_style(4, "main_menu_button", styles.main_menu)
+
+Set_ui_text(4, "main_menu_button", {
+    content = "Menu",
+    font_size = 20
+})
+
+Set_ui_transform(4, "main_menu_button", {
+    x = 285,
+    y = 650,
+    z = 0,
+    w = 120,
+    h = 50,
+    anchor_x = 0,
+    anchor_y = 0,
+    rotation = 0
+})

--- a/src/client/game_scene_loader.cpp
+++ b/src/client/game_scene_loader.cpp
@@ -80,6 +80,7 @@ void load_game_scene(engn::EngineContext& engine_ctx) {
     engine_ctx.add_system<cpnt::UITransform, cpnt::UIStyle>(sys::ui_background_renderer);
     engine_ctx.add_system<cpnt::UITransform, cpnt::UIText, cpnt::UIStyle>(sys::ui_text_renderer);
     engine_ctx.add_system<>(handle_connection_menu_ui_events);
+    engine_ctx.add_system<>(handle_game_pause_inputs);
 
     // Load assets
 

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -26,6 +26,7 @@ int main(void) {
     // NOLINTEND(cppcoreguidelines-pro-type-union-access)
 
     InitWindow(k_width, k_height, "FTL-Type");
+    SetExitKey(KEY_NULL);
     InitAudioDevice();
     SetTargetFPS(k_target_fps);
 
@@ -38,6 +39,7 @@ int main(void) {
     engine_ctx.add_scene_loader(1, load_main_menu_scene);
     engine_ctx.add_scene_loader(2, load_server_connection_scene);
     engine_ctx.add_scene_loader(3, load_multiplayer_game_scene);
+    engine_ctx.add_scene_loader(4, load_settings_menu_scene);
     engine_ctx.set_scene(1); // Game menu scene
 
     std::optional<Music> battle_music = engine_ctx.assets_manager.get_asset<Music>("battle_music");

--- a/src/client/main_menu_scene_loader.cpp
+++ b/src/client/main_menu_scene_loader.cpp
@@ -43,10 +43,10 @@ void load_main_menu_scene(engn::EngineContext& engine_ctx) {
     engine_ctx.add_system<>(sys::ui_press);
     engine_ctx.add_system<cpnt::UITransform, cpnt::UIStyle>(sys::ui_background_renderer);
     engine_ctx.add_system<cpnt::UITransform, cpnt::UIText, cpnt::UIStyle>(sys::ui_text_renderer);
-    engine_ctx.add_system<>(handle_main_menu_ui_events);
     engine_ctx.add_system<cpnt::Transform, cpnt::Star>(sys::star_scroll_system);
     engine_ctx.add_system<cpnt::Transform, cpnt::Sprite, cpnt::Star, cpnt::Velocity,
     cpnt::Particle>(sys::render_system);
+    engine_ctx.add_system<>(handle_main_menu_ui_events);
     
     
     const int k_width = static_cast<int>(engine_ctx.k_window_size.x); // NOLINT(cppcoreguidelines-pro-type-union-access)

--- a/src/client/multiplayer_game_scene_loader.cpp
+++ b/src/client/multiplayer_game_scene_loader.cpp
@@ -88,6 +88,7 @@ void load_multiplayer_game_scene(engn::EngineContext& engine_ctx) {
     engine_ctx.add_system<cpnt::UITransform, cpnt::UIStyle>(sys::ui_background_renderer);
     engine_ctx.add_system<cpnt::UITransform, cpnt::UIText, cpnt::UIStyle>(sys::ui_text_renderer);
     engine_ctx.add_system<>(handle_connection_menu_ui_events);
+    engine_ctx.add_system<>(handle_game_pause_inputs);
 
     static std::unique_ptr<NetworkClient> s_network_client;
 

--- a/src/client/scenes_loaders.h
+++ b/src/client/scenes_loaders.h
@@ -8,3 +8,4 @@ void load_main_menu_scene(engn::EngineContext& engine_ctx);
 void load_game_scene(engn::EngineContext& engine_ctx);
 void load_server_connection_scene(engn::EngineContext& engine_ctx);
 void load_multiplayer_game_scene(engn::EngineContext& engine_ctx);
+void load_settings_menu_scene(engn::EngineContext& engine_ctx);

--- a/src/client/settings_menu_scene_loader.cpp
+++ b/src/client/settings_menu_scene_loader.cpp
@@ -1,0 +1,38 @@
+#include "game_engine/api/lua.h"
+#include "game_engine/engine.h"
+#include "game_engine/systems/systems.h"
+#include "scenes_loaders.h"
+#include "systems/client_systems.h"
+
+#include <string>
+
+#include "sol/sol.hpp"
+
+using namespace engn;
+
+const std::string k_script_file = "scripts/lua/ui/settings_menu.lua";
+
+void load_settings_menu_scene(engn::EngineContext& engine_ctx) {
+    auto& reg = engine_ctx.registry;
+
+    engine_ctx.pending_rebind = ControlAction::None;
+
+    reg.register_component<cpnt::UIButton>();
+    reg.register_component<cpnt::UIFocusable>();
+    reg.register_component<cpnt::UIInteractable>();
+    reg.register_component<cpnt::UINavigation>();
+    reg.register_component<cpnt::UISlider>();
+    reg.register_component<cpnt::UIStyle>();
+    reg.register_component<cpnt::UIText>();
+    reg.register_component<cpnt::UITransform>();
+
+    engine_ctx.add_system<>(sys::fetch_inputs);
+    // engine_ctx.add_system<>(sys::log_inputs);
+    engine_ctx.add_system<cpnt::UITransform>(sys::ui_hover);
+    engine_ctx.add_system<>(sys::ui_press);
+    engine_ctx.add_system<cpnt::UITransform, cpnt::UIStyle>(sys::ui_background_renderer);
+    engine_ctx.add_system<cpnt::UITransform, cpnt::UIText, cpnt::UIStyle>(sys::ui_text_renderer);
+    engine_ctx.add_system<>(handle_settings_menu_ui_events);
+
+    engn::lua::load_lua_script_from_file(engine_ctx.lua_ctx->get_lua_state(), k_script_file);
+}

--- a/src/client/systems/client_systems.h
+++ b/src/client/systems/client_systems.h
@@ -10,3 +10,5 @@ class EngineContext;
 void handle_main_menu_ui_events(engn::EngineContext& ctx);
 void handle_connection_menu_ui_events(engn::EngineContext& ctx);
 void handle_connection_menu_ui_events(engn::EngineContext& engine_ctx);
+void handle_settings_menu_ui_events(engn::EngineContext& ctx);
+void handle_game_pause_inputs(engn::EngineContext& ctx);

--- a/src/client/systems/handle_game_pause_inputs.cpp
+++ b/src/client/systems/handle_game_pause_inputs.cpp
@@ -1,0 +1,15 @@
+#include "game_engine/engine.h"
+#include "systems/client_systems.h"
+
+using namespace engn;
+
+void handle_game_pause_inputs(engn::EngineContext& engine_ctx) {
+    const evts::KeyPressed* key_evt = engine_ctx.input_event_queue.get_last<evts::KeyPressed>();
+    if (!key_evt)
+        return;
+
+    if (key_evt->keycode == evts::KeyboardKeyCode::KeyEscape) {
+        engine_ctx.settings_return_scene = engine_ctx.get_current_scene();
+        engine_ctx.set_scene(4);
+    }
+}

--- a/src/client/systems/handle_main_menu_ui_events.cpp
+++ b/src/client/systems/handle_main_menu_ui_events.cpp
@@ -22,7 +22,8 @@ static void handle_ui_button_clicked(EngineContext& ctx, const evts::UIButtonCli
     } else if (tag_name == "play_multiplayer_button") {
         ctx.set_scene(2);
     } else if (tag_name == "setting_button") {
-        ctx.set_scene(3);
+        ctx.settings_return_scene = 1;
+        ctx.set_scene(4);
     } else if (tag_name == "exit_button") {
         ctx.should_quit = true;
     }

--- a/src/client/systems/handle_settings_menu_ui_events.cpp
+++ b/src/client/systems/handle_settings_menu_ui_events.cpp
@@ -1,0 +1,241 @@
+#include "game_engine/components/components.h"
+#include "game_engine/controls.h"
+#include "game_engine/engine.h"
+#include "systems/client_systems.h"
+
+#include <string>
+
+using namespace engn;
+
+static void handle_ui_button_clicked(EngineContext& ctx, const evts::UIButtonClicked& evt);
+static void sync_settings_texts(EngineContext& ctx);
+static void update_prompt_text(EngineContext& ctx);
+static void update_rebind_buttons(EngineContext& ctx);
+
+void handle_settings_menu_ui_events(engn::EngineContext& engine_ctx) {
+    const auto& evts = engine_ctx.ui_event_queue;
+
+    evts.for_each<evts::UIButtonClicked>(
+        [&engine_ctx](const evts::UIButtonClicked& evt) { handle_ui_button_clicked(engine_ctx, evt); });
+
+    const evts::KeyPressed* key_evt = engine_ctx.input_event_queue.get_last<evts::KeyPressed>();
+    if (key_evt && key_evt->keycode == evts::KeyboardKeyCode::KeyEscape) {
+        if (engine_ctx.settings_return_scene != 1) {
+            engine_ctx.pending_rebind = ControlAction::None;
+            engine_ctx.set_scene(engine_ctx.settings_return_scene);
+            return;
+        }
+    }
+
+    if (engine_ctx.pending_rebind != ControlAction::None) {
+        if (key_evt) {
+            switch (engine_ctx.pending_rebind) {
+                case ControlAction::MoveUp:
+                    engine_ctx.controls.move_up.primary = key_evt->keycode;
+                    break;
+                case ControlAction::MoveDown:
+                    engine_ctx.controls.move_down.primary = key_evt->keycode;
+                    break;
+                case ControlAction::MoveLeft:
+                    engine_ctx.controls.move_left.primary = key_evt->keycode;
+                    break;
+                case ControlAction::MoveRight:
+                    engine_ctx.controls.move_right.primary = key_evt->keycode;
+                    break;
+                case ControlAction::Shoot:
+                    engine_ctx.controls.shoot.primary = key_evt->keycode;
+                    break;
+                case ControlAction::None:
+                    break;
+            }
+            engine_ctx.pending_rebind = ControlAction::None;
+        }
+    }
+
+    sync_settings_texts(engine_ctx);
+    update_prompt_text(engine_ctx);
+    update_rebind_buttons(engine_ctx);
+}
+
+static void handle_ui_button_clicked(EngineContext& ctx, const evts::UIButtonClicked& evt) {
+    const auto& tags = ctx.registry.get_tag_registry();
+    std::string tag_name = tags.get_tag_name(evt.tag);
+
+    if (tag_name == "back_button") {
+        ctx.set_scene(ctx.settings_return_scene);
+    } else if (tag_name == "exit_button") {
+        ctx.should_quit = true;
+    } else if (tag_name == "main_menu_button") {
+        ctx.settings_return_scene = 1;
+        ctx.set_scene(1);
+    } else if (tag_name == "rebind_move_up") {
+        ctx.pending_rebind = (ctx.pending_rebind == ControlAction::MoveUp) ? ControlAction::None
+                                                                           : ControlAction::MoveUp;
+    } else if (tag_name == "rebind_move_down") {
+        ctx.pending_rebind = (ctx.pending_rebind == ControlAction::MoveDown) ? ControlAction::None
+                                                                             : ControlAction::MoveDown;
+    } else if (tag_name == "rebind_move_left") {
+        ctx.pending_rebind = (ctx.pending_rebind == ControlAction::MoveLeft) ? ControlAction::None
+                                                                             : ControlAction::MoveLeft;
+    } else if (tag_name == "rebind_move_right") {
+        ctx.pending_rebind = (ctx.pending_rebind == ControlAction::MoveRight) ? ControlAction::None
+                                                                              : ControlAction::MoveRight;
+    } else if (tag_name == "rebind_shoot") {
+        ctx.pending_rebind = (ctx.pending_rebind == ControlAction::Shoot) ? ControlAction::None
+                                                                          : ControlAction::Shoot;
+    }
+}
+
+static const char* keycode_to_label(evts::KeyboardKeyCode keycode) {
+    switch (keycode) {
+        case evts::KeyboardKeyCode::KeyA: return "Q";
+        case evts::KeyboardKeyCode::KeyB: return "B";
+        case evts::KeyboardKeyCode::KeyC: return "C";
+        case evts::KeyboardKeyCode::KeyD: return "D";
+        case evts::KeyboardKeyCode::KeyE: return "E";
+        case evts::KeyboardKeyCode::KeyF: return "F";
+        case evts::KeyboardKeyCode::KeyG: return "G";
+        case evts::KeyboardKeyCode::KeyH: return "H";
+        case evts::KeyboardKeyCode::KeyI: return "I";
+        case evts::KeyboardKeyCode::KeyJ: return "J";
+        case evts::KeyboardKeyCode::KeyK: return "K";
+        case evts::KeyboardKeyCode::KeyL: return "L";
+        case evts::KeyboardKeyCode::KeyM: return "M";
+        case evts::KeyboardKeyCode::KeyN: return "N";
+        case evts::KeyboardKeyCode::KeyO: return "O";
+        case evts::KeyboardKeyCode::KeyP: return "P";
+        case evts::KeyboardKeyCode::KeyQ: return "A";
+        case evts::KeyboardKeyCode::KeyR: return "R";
+        case evts::KeyboardKeyCode::KeyS: return "S";
+        case evts::KeyboardKeyCode::KeyT: return "T";
+        case evts::KeyboardKeyCode::KeyU: return "U";
+        case evts::KeyboardKeyCode::KeyV: return "V";
+        case evts::KeyboardKeyCode::KeyW: return "Z";
+        case evts::KeyboardKeyCode::KeyX: return "X";
+        case evts::KeyboardKeyCode::KeyY: return "Y";
+        case evts::KeyboardKeyCode::KeyZ: return "W";
+        case evts::KeyboardKeyCode::Key0: return "0";
+        case evts::KeyboardKeyCode::Key1: return "1";
+        case evts::KeyboardKeyCode::Key2: return "2";
+        case evts::KeyboardKeyCode::Key3: return "3";
+        case evts::KeyboardKeyCode::Key4: return "4";
+        case evts::KeyboardKeyCode::Key5: return "5";
+        case evts::KeyboardKeyCode::Key6: return "6";
+        case evts::KeyboardKeyCode::Key7: return "7";
+        case evts::KeyboardKeyCode::Key8: return "8";
+        case evts::KeyboardKeyCode::Key9: return "9";
+        case evts::KeyboardKeyCode::KeyEscape: return "Esc";
+        case evts::KeyboardKeyCode::KeyEnter: return "Enter";
+        case evts::KeyboardKeyCode::KeyTab: return "Tab";
+        case evts::KeyboardKeyCode::KeyBackspace: return "Backspace";
+        case evts::KeyboardKeyCode::KeyInsert: return "Insert";
+        case evts::KeyboardKeyCode::KeyDelete: return "Delete";
+        case evts::KeyboardKeyCode::KeyPeriod: return ".";
+        case evts::KeyboardKeyCode::KeyRight: return "Right";
+        case evts::KeyboardKeyCode::KeyLeft: return "Left";
+        case evts::KeyboardKeyCode::KeyDown: return "Down";
+        case evts::KeyboardKeyCode::KeyUp: return "Up";
+        case evts::KeyboardKeyCode::KeyPageUp: return "PageUp";
+        case evts::KeyboardKeyCode::KeyPageDown: return "PageDown";
+        case evts::KeyboardKeyCode::KeyHome: return "Home";
+        case evts::KeyboardKeyCode::KeyEnd: return "End";
+        case evts::KeyboardKeyCode::KeyCapsLock: return "CapsLock";
+        case evts::KeyboardKeyCode::KeyScrollLock: return "ScrollLock";
+        case evts::KeyboardKeyCode::KeyNumLock: return "NumLock";
+        case evts::KeyboardKeyCode::KeyPrintScreen: return "PrintScreen";
+        case evts::KeyboardKeyCode::KeyPause: return "Pause";
+        case evts::KeyboardKeyCode::KeyF1: return "F1";
+        case evts::KeyboardKeyCode::KeyF2: return "F2";
+        case evts::KeyboardKeyCode::KeyF3: return "F3";
+        case evts::KeyboardKeyCode::KeyF4: return "F4";
+        case evts::KeyboardKeyCode::KeyF5: return "F5";
+        case evts::KeyboardKeyCode::KeyF6: return "F6";
+        case evts::KeyboardKeyCode::KeyF7: return "F7";
+        case evts::KeyboardKeyCode::KeyF8: return "F8";
+        case evts::KeyboardKeyCode::KeyF9: return "F9";
+        case evts::KeyboardKeyCode::KeyF10: return "F10";
+        case evts::KeyboardKeyCode::KeyF11: return "F11";
+        case evts::KeyboardKeyCode::KeyF12: return "F12";
+        case evts::KeyboardKeyCode::KeySpace: return "Space";
+        case evts::KeyboardKeyCode::KeyLeftShift: return "LShift";
+        case evts::KeyboardKeyCode::KeyRightShift: return "RShift";
+        case evts::KeyboardKeyCode::KeyLeftControl: return "LCtrl";
+        case evts::KeyboardKeyCode::KeyRightControl: return "RCtrl";
+        case evts::KeyboardKeyCode::KeyLeftAlt: return "LAlt";
+        case evts::KeyboardKeyCode::KeyRightAlt: return "RAlt";
+        case evts::KeyboardKeyCode::KeyLeftSuper: return "LSuper";
+        case evts::KeyboardKeyCode::KeyRightSuper: return "RSuper";
+        case evts::KeyboardKeyCode::KeyUnknown: return "Unbound";
+    }
+    return "Unbound";
+}
+
+static std::string format_binding(const char* label, const ControlBinding& binding) {
+    const bool k_has_primary = binding.primary != evts::KeyboardKeyCode::KeyUnknown;
+    const bool k_has_secondary = binding.secondary != evts::KeyboardKeyCode::KeyUnknown;
+    std::string text = std::string(label) + ": ";
+    if (k_has_primary)
+        text += keycode_to_label(binding.primary);
+    if (k_has_secondary) {
+        if (k_has_primary)
+            text += " / ";
+        text += keycode_to_label(binding.secondary);
+    }
+    if (!k_has_primary && !k_has_secondary)
+        text += "Unbound";
+    return text;
+}
+
+static void set_text_if_exists(EngineContext& ctx, const char* tag, const std::string& value) {
+    auto ent_opt = ctx.registry.get_tag_registry().get_entity(tag);
+    if (!ent_opt.has_value())
+        return;
+    auto& texts = ctx.registry.get_components<cpnt::UIText>();
+    auto& text = texts[ent_opt.value()];
+    if (!text.has_value())
+        return;
+    text->content = value;
+}
+
+static void sync_settings_texts(EngineContext& ctx) {
+    set_text_if_exists(ctx, "mapping_move_up", format_binding("Move Up", ctx.controls.move_up));
+    set_text_if_exists(ctx, "mapping_move_down", format_binding("Move Down", ctx.controls.move_down));
+    set_text_if_exists(ctx, "mapping_move_left", format_binding("Move Left", ctx.controls.move_left));
+    set_text_if_exists(ctx, "mapping_move_right", format_binding("Move Right", ctx.controls.move_right));
+    set_text_if_exists(ctx, "mapping_shoot", format_binding("Shoot", ctx.controls.shoot));
+}
+
+static const char* action_to_label(ControlAction action) {
+    switch (action) {
+        case ControlAction::MoveUp: return "Move Up";
+        case ControlAction::MoveDown: return "Move Down";
+        case ControlAction::MoveLeft: return "Move Left";
+        case ControlAction::MoveRight: return "Move Right";
+        case ControlAction::Shoot: return "Shoot";
+        case ControlAction::None: return "";
+    }
+    return "";
+}
+
+static void update_prompt_text(EngineContext& ctx) {
+    if (ctx.pending_rebind == ControlAction::None) {
+        set_text_if_exists(ctx, "rebind_prompt", "Click Rebind to change controls");
+        return;
+    }
+    std::string prompt = "Press a key for ";
+    prompt += action_to_label(ctx.pending_rebind);
+    set_text_if_exists(ctx, "rebind_prompt", prompt);
+}
+
+static void update_rebind_buttons(EngineContext& ctx) {
+    set_text_if_exists(ctx, "rebind_move_up",
+                       ctx.pending_rebind == ControlAction::MoveUp ? "Cancel" : "Rebind");
+    set_text_if_exists(ctx, "rebind_move_down",
+                       ctx.pending_rebind == ControlAction::MoveDown ? "Cancel" : "Rebind");
+    set_text_if_exists(ctx, "rebind_move_left",
+                       ctx.pending_rebind == ControlAction::MoveLeft ? "Cancel" : "Rebind");
+    set_text_if_exists(ctx, "rebind_move_right",
+                       ctx.pending_rebind == ControlAction::MoveRight ? "Cancel" : "Rebind");
+    set_text_if_exists(ctx, "rebind_shoot",
+                       ctx.pending_rebind == ControlAction::Shoot ? "Cancel" : "Rebind");
+}

--- a/src/game_engine/controls.h
+++ b/src/game_engine/controls.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "events/keyboard_events.h"
+
+namespace engn {
+
+struct ControlBinding {
+    evts::KeyboardKeyCode primary = evts::KeyboardKeyCode::KeyUnknown;
+    evts::KeyboardKeyCode secondary = evts::KeyboardKeyCode::KeyUnknown;
+};
+
+struct ControlScheme {
+    ControlBinding move_up;
+    ControlBinding move_down;
+    ControlBinding move_left;
+    ControlBinding move_right;
+    ControlBinding shoot;
+};
+
+enum class ControlAction {
+    None = 0,
+    MoveUp,
+    MoveDown,
+    MoveLeft,
+    MoveRight,
+    Shoot
+};
+
+inline ControlScheme make_default_controls() {
+    ControlScheme scheme;
+    scheme.move_up = {evts::KeyboardKeyCode::KeyW, evts::KeyboardKeyCode::KeyUp};
+    scheme.move_down = {evts::KeyboardKeyCode::KeyS, evts::KeyboardKeyCode::KeyDown};
+    scheme.move_left = {evts::KeyboardKeyCode::KeyA, evts::KeyboardKeyCode::KeyLeft};
+    scheme.move_right = {evts::KeyboardKeyCode::KeyD, evts::KeyboardKeyCode::KeyRight};
+    scheme.shoot = {evts::KeyboardKeyCode::KeySpace, evts::KeyboardKeyCode::KeyUnknown};
+    return scheme;
+}
+
+} // namespace engn

--- a/src/game_engine/engine.h
+++ b/src/game_engine/engine.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "assets_manager.h"
+#include "controls.h"
 #include "ecs/registry.h"
 #include "events/event_queue.h"
 #include "events/events.h"
@@ -44,6 +45,10 @@ class EngineContext {
     const size_t k_stars = 1000;
     const size_t k_max_bullets = 100;
     const size_t k_max_enemies = 8;
+
+    ControlScheme controls = make_default_controls();
+    ControlAction pending_rebind = ControlAction::None;
+    unsigned char settings_return_scene = 1;
 
     std::string server_ip;
     std::uint16_t server_port;

--- a/src/game_engine/systems/player_control_system.cpp
+++ b/src/game_engine/systems/player_control_system.cpp
@@ -1,6 +1,7 @@
 #include "components/components.h"
 #include "ecs/zipper.h"
 #include "engine.h"
+#include "game_engine/controls.h"
 #include "raylib.h"
 #include "systems/systems.h"
 
@@ -44,6 +45,108 @@ constexpr float k_bullet_sprite_y = 105.0f;
 constexpr float k_bullet_scale = 2.0f;
 } // namespace
 
+static int keycode_to_raylib(evts::KeyboardKeyCode keycode) {
+    switch (keycode) {
+        case evts::KeyboardKeyCode::KeyA: return KEY_A;
+        case evts::KeyboardKeyCode::KeyB: return KEY_B;
+        case evts::KeyboardKeyCode::KeyC: return KEY_C;
+        case evts::KeyboardKeyCode::KeyD: return KEY_D;
+        case evts::KeyboardKeyCode::KeyE: return KEY_E;
+        case evts::KeyboardKeyCode::KeyF: return KEY_F;
+        case evts::KeyboardKeyCode::KeyG: return KEY_G;
+        case evts::KeyboardKeyCode::KeyH: return KEY_H;
+        case evts::KeyboardKeyCode::KeyI: return KEY_I;
+        case evts::KeyboardKeyCode::KeyJ: return KEY_J;
+        case evts::KeyboardKeyCode::KeyK: return KEY_K;
+        case evts::KeyboardKeyCode::KeyL: return KEY_L;
+        case evts::KeyboardKeyCode::KeyM: return KEY_M;
+        case evts::KeyboardKeyCode::KeyN: return KEY_N;
+        case evts::KeyboardKeyCode::KeyO: return KEY_O;
+        case evts::KeyboardKeyCode::KeyP: return KEY_P;
+        case evts::KeyboardKeyCode::KeyQ: return KEY_Q;
+        case evts::KeyboardKeyCode::KeyR: return KEY_R;
+        case evts::KeyboardKeyCode::KeyS: return KEY_S;
+        case evts::KeyboardKeyCode::KeyT: return KEY_T;
+        case evts::KeyboardKeyCode::KeyU: return KEY_U;
+        case evts::KeyboardKeyCode::KeyV: return KEY_V;
+        case evts::KeyboardKeyCode::KeyW: return KEY_W;
+        case evts::KeyboardKeyCode::KeyX: return KEY_X;
+        case evts::KeyboardKeyCode::KeyY: return KEY_Y;
+        case evts::KeyboardKeyCode::KeyZ: return KEY_Z;
+        case evts::KeyboardKeyCode::Key0: return KEY_ZERO;
+        case evts::KeyboardKeyCode::Key1: return KEY_ONE;
+        case evts::KeyboardKeyCode::Key2: return KEY_TWO;
+        case evts::KeyboardKeyCode::Key3: return KEY_THREE;
+        case evts::KeyboardKeyCode::Key4: return KEY_FOUR;
+        case evts::KeyboardKeyCode::Key5: return KEY_FIVE;
+        case evts::KeyboardKeyCode::Key6: return KEY_SIX;
+        case evts::KeyboardKeyCode::Key7: return KEY_SEVEN;
+        case evts::KeyboardKeyCode::Key8: return KEY_EIGHT;
+        case evts::KeyboardKeyCode::Key9: return KEY_NINE;
+        case evts::KeyboardKeyCode::KeyEscape: return KEY_ESCAPE;
+        case evts::KeyboardKeyCode::KeyEnter: return KEY_ENTER;
+        case evts::KeyboardKeyCode::KeyTab: return KEY_TAB;
+        case evts::KeyboardKeyCode::KeyBackspace: return KEY_BACKSPACE;
+        case evts::KeyboardKeyCode::KeyInsert: return KEY_INSERT;
+        case evts::KeyboardKeyCode::KeyDelete: return KEY_DELETE;
+        case evts::KeyboardKeyCode::KeyPeriod: return KEY_PERIOD;
+        case evts::KeyboardKeyCode::KeyRight: return KEY_RIGHT;
+        case evts::KeyboardKeyCode::KeyLeft: return KEY_LEFT;
+        case evts::KeyboardKeyCode::KeyDown: return KEY_DOWN;
+        case evts::KeyboardKeyCode::KeyUp: return KEY_UP;
+        case evts::KeyboardKeyCode::KeyPageUp: return KEY_PAGE_UP;
+        case evts::KeyboardKeyCode::KeyPageDown: return KEY_PAGE_DOWN;
+        case evts::KeyboardKeyCode::KeyHome: return KEY_HOME;
+        case evts::KeyboardKeyCode::KeyEnd: return KEY_END;
+        case evts::KeyboardKeyCode::KeyCapsLock: return KEY_CAPS_LOCK;
+        case evts::KeyboardKeyCode::KeyScrollLock: return KEY_SCROLL_LOCK;
+        case evts::KeyboardKeyCode::KeyNumLock: return KEY_NUM_LOCK;
+        case evts::KeyboardKeyCode::KeyPrintScreen: return KEY_PRINT_SCREEN;
+        case evts::KeyboardKeyCode::KeyPause: return KEY_PAUSE;
+        case evts::KeyboardKeyCode::KeyF1: return KEY_F1;
+        case evts::KeyboardKeyCode::KeyF2: return KEY_F2;
+        case evts::KeyboardKeyCode::KeyF3: return KEY_F3;
+        case evts::KeyboardKeyCode::KeyF4: return KEY_F4;
+        case evts::KeyboardKeyCode::KeyF5: return KEY_F5;
+        case evts::KeyboardKeyCode::KeyF6: return KEY_F6;
+        case evts::KeyboardKeyCode::KeyF7: return KEY_F7;
+        case evts::KeyboardKeyCode::KeyF8: return KEY_F8;
+        case evts::KeyboardKeyCode::KeyF9: return KEY_F9;
+        case evts::KeyboardKeyCode::KeyF10: return KEY_F10;
+        case evts::KeyboardKeyCode::KeyF11: return KEY_F11;
+        case evts::KeyboardKeyCode::KeyF12: return KEY_F12;
+        case evts::KeyboardKeyCode::KeySpace: return KEY_SPACE;
+        case evts::KeyboardKeyCode::KeyLeftShift: return KEY_LEFT_SHIFT;
+        case evts::KeyboardKeyCode::KeyRightShift: return KEY_RIGHT_SHIFT;
+        case evts::KeyboardKeyCode::KeyLeftControl: return KEY_LEFT_CONTROL;
+        case evts::KeyboardKeyCode::KeyRightControl: return KEY_RIGHT_CONTROL;
+        case evts::KeyboardKeyCode::KeyLeftAlt: return KEY_LEFT_ALT;
+        case evts::KeyboardKeyCode::KeyRightAlt: return KEY_RIGHT_ALT;
+        case evts::KeyboardKeyCode::KeyLeftSuper: return KEY_LEFT_SUPER;
+        case evts::KeyboardKeyCode::KeyRightSuper: return KEY_RIGHT_SUPER;
+        case evts::KeyboardKeyCode::KeyUnknown: return KEY_NULL;
+    }
+    return KEY_NULL;
+}
+
+static bool is_key_down(evts::KeyboardKeyCode keycode) {
+    const int k_key = keycode_to_raylib(keycode);
+    return k_key != KEY_NULL && IsKeyDown(k_key);
+}
+
+static bool is_key_pressed(evts::KeyboardKeyCode keycode) {
+    const int k_key = keycode_to_raylib(keycode);
+    return k_key != KEY_NULL && IsKeyPressed(k_key);
+}
+
+static bool is_binding_down(const ControlBinding& binding) {
+    return is_key_down(binding.primary) || is_key_down(binding.secondary);
+}
+
+static bool is_binding_pressed(const ControlBinding& binding) {
+    return is_key_pressed(binding.primary) || is_key_pressed(binding.secondary);
+}
+
 void sys::player_control_system(EngineContext& ctx, ecs::SparseArray<cpnt::Transform> const& positions,
                                 ecs::SparseArray<cpnt::Player> const& players,
                                 ecs::SparseArray<cpnt::Sprite> const& sprites,
@@ -79,13 +182,13 @@ void sys::player_control_system(EngineContext& ctx, ecs::SparseArray<cpnt::Trans
             auto& vel = reg.get_components<cpnt::Velocity>()[idx];
 
             if (pos) {
-                if (IsKeyDown(KEY_RIGHT) || IsKeyDown(KEY_D))
+                if (is_binding_down(ctx.controls.move_right))
                     pos->x += k_player_speed * dt;
-                if (IsKeyDown(KEY_LEFT) || IsKeyDown(KEY_A))
+                if (is_binding_down(ctx.controls.move_left))
                     pos->x -= k_player_speed * dt;
-                if (IsKeyDown(KEY_UP) || IsKeyDown(KEY_W))
+                if (is_binding_down(ctx.controls.move_up))
                     pos->y -= k_player_speed * dt;
-                if (IsKeyDown(KEY_DOWN) || IsKeyDown(KEY_S))
+                if (is_binding_down(ctx.controls.move_down))
                     pos->y += k_player_speed * dt;
 
                 // Clamp position
@@ -102,7 +205,7 @@ void sys::player_control_system(EngineContext& ctx, ecs::SparseArray<cpnt::Trans
 
                 // Animate sprite
                 if (sprite) {
-                    if (IsKeyDown(KEY_UP) || IsKeyDown(KEY_W)) {
+                    if (is_binding_down(ctx.controls.move_up)) {
                         if (sprite->frame <= k_animation_frame_limit && sprite->source_rect.x != k_sprite_up_right) {
                             sprite->frame++;
                             sprite->source_rect.x = k_sprite_up_anim;
@@ -110,7 +213,7 @@ void sys::player_control_system(EngineContext& ctx, ecs::SparseArray<cpnt::Trans
                             sprite->source_rect.x = k_sprite_up_right;
                             sprite->frame = 0;
                         }
-                    } else if (IsKeyDown(KEY_DOWN) || IsKeyDown(KEY_S)) {
+                    } else if (is_binding_down(ctx.controls.move_down)) {
                         if (sprite->frame <= k_animation_frame_limit && sprite->source_rect.x != k_sprite_down_left) {
                             sprite->frame++;
                             sprite->source_rect.x = k_sprite_down_anim;
@@ -133,9 +236,9 @@ void sys::player_control_system(EngineContext& ctx, ecs::SparseArray<cpnt::Trans
                             sprite->frame = 0;
                         }
                     }
-                    if (IsKeyDown(KEY_LEFT) || IsKeyDown(KEY_A)) {
+                    if (is_binding_down(ctx.controls.move_left)) {
                         vel->vz = -k_rotation_speed;
-                    } else if (IsKeyDown(KEY_RIGHT) || IsKeyDown(KEY_D)) {
+                    } else if (is_binding_down(ctx.controls.move_right)) {
                         vel->vz = k_rotation_speed;
                     } else {
                         vel->vz = 0.0f;
@@ -144,9 +247,9 @@ void sys::player_control_system(EngineContext& ctx, ecs::SparseArray<cpnt::Trans
 
                 // Rotation based on movement
                 if (vel) {
-                    if (IsKeyDown(KEY_LEFT) || IsKeyDown(KEY_A)) {
+                    if (is_binding_down(ctx.controls.move_left)) {
                         vel->vrz = -k_rotation_speed;
-                    } else if (IsKeyDown(KEY_RIGHT) || IsKeyDown(KEY_D)) {
+                    } else if (is_binding_down(ctx.controls.move_right)) {
                         vel->vrz = k_rotation_speed;
                     } else {
                         vel->vrz = 0.0f;
@@ -154,7 +257,7 @@ void sys::player_control_system(EngineContext& ctx, ecs::SparseArray<cpnt::Trans
                 }
 
                 // Shoot
-                if (IsKeyPressed(KEY_SPACE)) {
+                if (is_binding_pressed(ctx.controls.shoot)) {
                     auto bullet = reg.spawn_entity();
                     reg.add_component(bullet, cpnt::Transform{pos->x + k_bullet_offset_x, pos->y + k_bullet_offset_y,
                                                               0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 1.0f});


### PR DESCRIPTION
## Summary
Add a settings menu scene with control rebinding, plus pause-to-settings behavior and customizable player controls.

## Related Issue(s)
- 

## Additions
- Added a new Lua script for the settings menu UI.
- Created a new scene loader for the settings menu.
- Integrated control rebinding functionality, allowing users to change key bindings for movement and shooting actions.
- Updated the main menu to navigate to the settings menu.
- Added a system to handle game pause inputs, allowing users to return to the settings menu.
- Enhanced the player control system to utilize customizable key bindings.
- Updated the engine context to include control schemes and pending rebind states.

## Risk & Rollback
- Low risk: UI-only changes and input mapping logic.
- Rollback by reverting the settings menu scene and control binding changes.

## Testing
1. Build `cmake --build build`.
2. Launch `./r-type_client`.
3. Open Settings from the main menu, use Rebind, and verify labels update.
4. Enter a game, press `Esc` to open Settings and `Esc` again to return.

## Checklist
- [x] Source branch is based on `dev`
- [ ] Linked to the correct GitHub issues
- [x] Added at least 2 people as reviewers, 4 if you are merging into main
- [x] No conflicts
- [ ] Documentation deployment CI must pass
