### PR TITLE
✨ Add package tracking and acknowledgment

### DIFF
--- a/src/client/network_client.cpp
+++ b/src/client/network_client.cpp
@@ -32,6 +32,7 @@ void NetworkClient::connect(const std::string& host, std::uint16_t port, const s
         asio::ip::udp::resolver resolver(m_io);
         auto endpoints = resolver.resolve(asio::ip::udp::v4(), host, std::to_string(port));
         asio::ip::udp::endpoint server_endpoint = *endpoints.begin();
+        m_server_endpoint = server_endpoint;
 
         // Create session pointing to server
         m_session = std::make_shared<net::Session>(m_io, server_endpoint);
@@ -138,7 +139,7 @@ bool NetworkClient::is_message_acknowledged(std::uint32_t id) const {
     if (!m_connected.load() || !m_session) {
         return false;
     }
-    return m_session->is_message_acknowledged(id);
+    return m_session->is_message_acknowledged(id, m_server_endpoint);
 }
 
 void NetworkClient::disconnect() {

--- a/src/client/network_client.h
+++ b/src/client/network_client.h
@@ -51,6 +51,7 @@ class NetworkClient {
     std::atomic<bool> m_running{false};
     std::atomic<bool> m_connected{false};
     uint32_t m_player_id{0};
+    asio::ip::udp::endpoint m_server_endpoint{};
     OnLoginCallback m_on_login;
     OnPacketCallback m_on_reliable;
     OnPacketCallback m_on_unreliable;

--- a/src/networking/rtp/networking.h
+++ b/src/networking/rtp/networking.h
@@ -156,11 +156,11 @@ class ReliableSendQueue {
     /**
      * Tracks a reliable packet that has just been transmitted.
      */
-    void track(const Packet& packet, std::chrono::steady_clock::time_point now);
+    void track(const Packet& packet, std::chrono::steady_clock::time_point now, const asio::ip::udp::endpoint& endpoint);
     /**
-     * Removes packets covered by the latest acknowledgement identifier.
+     * Removes packets covered by the latest acknowledgement identifier from a specific endpoint.
      */
-    void acknowledge(std::uint32_t ackId);
+    void acknowledge(std::uint32_t ackId, const asio::ip::udp::endpoint& endpoint);
     /**
      * Returns packets that have exceeded their retransmission timeout.
      */
@@ -175,7 +175,7 @@ class ReliableSendQueue {
      */
     std::vector<std::uint32_t> take_failures();
 
-    [[nodiscard]] bool is_acknowledged(std::uint32_t sequence) const;
+    [[nodiscard]] bool is_acknowledged(std::uint32_t sequence, const asio::ip::udp::endpoint& endpoint) const;
 
   private:
     struct Pending {
@@ -183,6 +183,7 @@ class ReliableSendQueue {
         std::chrono::steady_clock::time_point m_last_sent;
         std::size_t m_attempts = 0;
         std::chrono::milliseconds m_rto{};
+        asio::ip::udp::endpoint m_endpoint{};
     };
 
     std::deque<Pending> m_queue{};
@@ -285,9 +286,9 @@ class Session : public std::enable_shared_from_this<Session> {
      */
     std::uint32_t send(Packet packet, const asio::ip::udp::endpoint& endpoint, bool reliable = false);
     /**
-     * Checks if a specific message ID (sequence number) has been acknowledged.
+     * Checks if a specific message ID (sequence number) has been acknowledged by a specific endpoint.
      */
-    [[nodiscard]] bool is_message_acknowledged(std::uint32_t id) const;
+    [[nodiscard]] bool is_message_acknowledged(std::uint32_t id, const asio::ip::udp::endpoint& endpoint) const;
     /**
      * Updates the fragment payload size to a negotiated value (bounded by k_max_payload_size).
      */


### PR DESCRIPTION
## Summary
This PR add the tracking of the acknowledgment on a reliable packet
The function `send_reliable` now returns the id of the message, which can be used by a function to check if the client received the packet

## Related Issue(s)
closes #98 

## Additions
- handle of IDs for the receptions of ACK

## Checklist
- [x] Source branch is based on `dev`
- [x] Linked to the correct GitHub issues
- [x] Added at least 2 people as reviewers, 4 if you are merging into main
- [x] No conflicts
- [x] Documentation deployment CI must pass
