### PR TITLE
🐛 Fix windows processes not working correctly

### DIFF
--- a/src/client/game_scene_loader.cpp
+++ b/src/client/game_scene_loader.cpp
@@ -16,7 +16,7 @@ constexpr float k_rand_divisor = 1000.0f;
 } // namespace
 
 static float randf() {
-    return static_cast<float>(rand() % k_rand_range) / k_rand_divisor;
+    return static_cast<float>(rand() % k_rand_range) / k_rand_divisor; // NOLINT(clang-analyzer-security.insecureAPI.rand)
 }
 
 void load_game_scene(engn::EngineContext& engine_ctx) {

--- a/src/client/lobby_scene_loader.cpp
+++ b/src/client/lobby_scene_loader.cpp
@@ -17,7 +17,7 @@ constexpr float k_rand_divisor = 1000.0f;
 } // namespace
 
 static float randf() {
-    return static_cast<float>(rand() % k_rand_range) / k_rand_divisor;
+    return static_cast<float>(rand() % k_rand_range) / k_rand_divisor; // NOLINT(clang-analyzer-security.insecureAPI.rand)
 }
 
 const std::string k_script_file = "scripts/lua/ui/lobby_menu.lua";

--- a/src/client/main_menu_scene_loader.cpp
+++ b/src/client/main_menu_scene_loader.cpp
@@ -18,7 +18,7 @@ constexpr float k_rand_divisor = 1000.0f;
 } // namespace
 
 static float randf() {
-    return static_cast<float>(rand() % k_rand_range) / k_rand_divisor;
+    return static_cast<float>(rand() % k_rand_range) / k_rand_divisor; // NOLINT(clang-analyzer-security.insecureAPI.rand)
 }
 
 void load_main_menu_scene(engn::EngineContext& engine_ctx) {

--- a/src/client/multiplayer_game_scene_loader.cpp
+++ b/src/client/multiplayer_game_scene_loader.cpp
@@ -18,7 +18,7 @@ constexpr float k_rand_divisor = 1000.0f;
 } // namespace
 
 static float randf() {
-    return static_cast<float>(rand() % k_rand_range) / k_rand_divisor;
+    return static_cast<float>(rand() % k_rand_range) / k_rand_divisor; // NOLINT(clang-analyzer-security.insecureAPI.rand)
 }
 
 void load_multiplayer_game_scene(engn::EngineContext& engine_ctx) {

--- a/src/game_engine/systems/particle_emission_system.cpp
+++ b/src/game_engine/systems/particle_emission_system.cpp
@@ -22,7 +22,7 @@ constexpr float k_particle_lifetime = 0.5f;
 } // namespace
 
 static float randf() {
-    return static_cast<float>(rand() % k_rand_range) / k_rand_divisor;
+    return static_cast<float>(rand() % k_rand_range) / k_rand_divisor; // NOLINT(clang-analyzer-security.insecureAPI.rand)
 }
 
 void sys::particle_emission_system(EngineContext& ctx, ecs::SparseArray<cpnt::Transform> const& positions,

--- a/src/server/lobby_manager.cpp
+++ b/src/server/lobby_manager.cpp
@@ -115,35 +115,37 @@ void GameLobby::fork_and_run_lobby_process() {
     // Windows implementation using CreateProcess
     STARTUPINFOA si = {sizeof(si)};
     PROCESS_INFORMATION pi = {};
-    
-    std::string cmd_line = "r-type_server.exe -lobby " + std::to_string(m_lobby_id) + 
-                           " -port " + std::to_string(m_port);
-    
-    if (!CreateProcessA(NULL, const_cast<char*>(cmd_line.c_str()), NULL, NULL, FALSE, 
+    char exe_path[MAX_PATH];
+    GetModuleFileNameA(NULL, exe_path, MAX_PATH);
+
+    std::string cmd_line = std::string(exe_path) + " -islobby -lobby-id " +
+                           std::to_string(m_lobby_id) + " -p " + std::to_string(m_port);
+
+    if (!CreateProcessA(NULL, const_cast<char*>(cmd_line.c_str()), NULL, NULL, FALSE,
                         0, NULL, NULL, &si, &pi)) {
         LOG_ERROR("Failed to create process for lobby {}: {}", m_lobby_id, GetLastError());
         m_running = false;
         throw std::runtime_error("CreateProcess failed");
     }
-    
+
     m_process_handle = pi.hProcess;
     CloseHandle(pi.hThread);
 #else
     // Unix implementation using fork
     pid_t pid = fork();
-    
+
     if (pid < 0) {
         LOG_ERROR("Failed to fork process for lobby {}", m_lobby_id);
         m_running = false;
         throw std::runtime_error("Fork failed");
     }
-    
+
     if (pid == 0) {
         // Child process
         run_lobby_in_child_process(m_lobby_id, m_lobby_name, m_port, m_max_players);
         _exit(0);
     }
-    
+
     m_process_handle = pid;
 #endif
 }
@@ -151,7 +153,7 @@ void GameLobby::fork_and_run_lobby_process() {
 void GameLobby::run_lobby_in_child_process(std::uint32_t lobby_id, const std::string& lobby_name,
                                            std::uint16_t port, std::uint8_t max_players) {
     try {
-        LOG_INFO("Lobby '{}' process started (PID: {})", lobby_name, 
+        LOG_INFO("Lobby '{}' process started (PID: {})", lobby_name,
 #ifdef _WIN32
                  GetCurrentProcessId()
 #else
@@ -199,7 +201,7 @@ void GameLobby::run_lobby_in_child_process(std::uint32_t lobby_id, const std::st
 
         server->stop();
         LOG_INFO("Lobby '{}' process exiting gracefully", lobby_name);
-        
+
     } catch (const std::exception& e) {
         LOG_ERROR("Lobby '{}' process error: {}", lobby_name, e.what());
     }

--- a/src/server/lobby_manager.h
+++ b/src/server/lobby_manager.h
@@ -76,13 +76,13 @@ class GameLobby {
     process_handle_t get_process_handle() const {
         return m_process_handle;
     }
+    
+    // Static function to run lobby in child process (public for Windows lobby mode)
+    static void run_lobby_in_child_process(std::uint32_t lobby_id, const std::string& lobby_name, 
+        std::uint16_t port, std::uint8_t max_players);
 
   private:
     void fork_and_run_lobby_process();
-    
-    // Static function to run lobby in child process
-    static void run_lobby_in_child_process(std::uint32_t lobby_id, const std::string& lobby_name, 
-        std::uint16_t port, std::uint8_t max_players);
 
     std::uint32_t m_lobby_id;
     std::string m_lobby_name;

--- a/src/server/main.cpp
+++ b/src/server/main.cpp
@@ -37,13 +37,27 @@ constexpr std::uint16_t k_lobby_base_port = 9000; // Lobbies will use ports star
 } // namespace
 
 int main(int argc, char** argv) {
-    // Parse port from args
+    // Parse command line arguments
     std::uint16_t port = k_default_port;
+    bool is_lobby = false;
+    std::uint32_t lobby_id = 0;
+    
     for (int i = 1; i < argc; i++) {
         if (std::string(argv[i]) == "-p") { // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
             port = static_cast<std::uint16_t>(
                 std::stoi(argv[i + 1])); // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        } else if (std::string(argv[i]) == "-islobby") { // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+            is_lobby = true;
+        } else if (std::string(argv[i]) == "-lobby-id") { // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+            lobby_id = static_cast<std::uint32_t>(
+                std::stoul(argv[i + 1])); // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
         }
+    }
+
+    if (is_lobby) {
+        std::string lobby_name = "Lobby_" + std::to_string(lobby_id);
+        GameLobby::run_lobby_in_child_process(lobby_id, lobby_name, port, 4);
+        return 0;
     }
 
     setup_signal_handling();

--- a/src/server/server_loader.cpp
+++ b/src/server/server_loader.cpp
@@ -18,7 +18,7 @@ constexpr float k_rand_divisor = 1000.0f;
 } // namespace
 
 static float randf() {
-    return static_cast<float>(rand() % k_rand_range) / k_rand_divisor;
+    return static_cast<float>(rand() % k_rand_range) / k_rand_divisor; // NOLINT(clang-analyzer-security.insecureAPI.rand)
 }
 
 void load_server_scene(engn::EngineContext& engine_ctx) {


### PR DESCRIPTION
## Summary
This PR fixes an issue with the process handling of the server lobby handler on Windows OS

## Related Issue(s)
#122 

<!-- ########## (BUG)FIX PULL REQUEST ##########-->
## Root Cause & Solution
Windows doesn't copy the program when creating a new process
So, the fix is to execute r-type-server.exe with as argument `-islobby` and `-lobby-id <id>` to start a lobby process


<!-- Keep this for all PRs -->
## Testing
1. Be on Windows
2. Compile
3. on a client, connect to the server, create lobbies and see if they stay or not

## Checklist
- [x] Source branch is based on `dev`
- [x] Linked to the correct GitHub issues
- [x] Added at least 2 people as reviewers, 4 if you are merging into main
- [x] No conflicts
- [x] Documentation deployment CI must pass
