### PR TITLE
✨ Add Conan as secondary packet manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Build artifacts
 build/
 .cache/
+CMakeUserPresets.json
 
 # Executables files
 r-type*.exe

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,78 @@ project(R-Type
     LANGUAGES CXX C
 )
 
+find_program(CONAN_CMD conan)
+option(USE_CONAN "Force Use Conan" OFF)
+
+if(NOT USE_CONAN AND CONAN_CMD)
+    message(STATUS "Checking network connectivity to GitHub for CPM...")
+    file(DOWNLOAD "https://github.com" ${CMAKE_BINARY_DIR}/github_ping
+        TIMEOUT 5
+        STATUS PING_STATUS
+        LOG PING_LOG
+    )
+    list(GET PING_STATUS 0 PING_CODE)
+
+    if(PING_CODE EQUAL 0)
+        message(STATUS "Network OK. Using CPM (Primary).")
+    else()
+        message(WARNING "Network unreachable (Error: ${PING_CODE}). Switching to Conan fallback (Secondary).")
+        set(USE_CONAN ON)
+    endif()
+endif()
+# -------------------------------
+
+if(USE_CONAN)
+    if(NOT CONAN_CMD)
+        message(WARNING "Conan requested (or triggered by fallback) but 'conan' not found.")
+    else()
+        message(STATUS "Conan active: ${CONAN_CMD}. Preparing local dependencies...")
+
+        function(run_conan_install BUILD_TYPE)
+            message(STATUS "Running Conan for build type: ${BUILD_TYPE}")
+            execute_process(
+                COMMAND ${CONAN_CMD} install ${CMAKE_SOURCE_DIR}
+                        --output-folder=${CMAKE_BINARY_DIR}
+                        --build=missing
+                        -s build_type=${BUILD_TYPE}
+                RESULT_VARIABLE CONAN_RESULT
+            )
+            if(NOT CONAN_RESULT EQUAL 0)
+                message(WARNING "Conan install failed for ${BUILD_TYPE}.")
+            else()
+                set(CPM_USE_LOCAL_PACKAGES ON PARENT_SCOPE)
+
+                file(GLOB_RECURSE CONAN_TOOLCHAINS "${CMAKE_BINARY_DIR}/conan_toolchain.cmake")
+
+                foreach(TOOLCHAIN_FILE ${CONAN_TOOLCHAINS})
+                    get_filename_component(GENERATORS_DIR ${TOOLCHAIN_FILE} DIRECTORY)
+                    list(APPEND CMAKE_PREFIX_PATH "${GENERATORS_DIR}")
+                    list(APPEND CMAKE_MODULE_PATH "${GENERATORS_DIR}")
+                endforeach()
+
+                set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH}" PARENT_SCOPE)
+                set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" PARENT_SCOPE)
+            endif()
+        endfunction()
+
+        get_property(IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+        if(IS_MULTI_CONFIG)
+            foreach(TYPE ${CMAKE_CONFIGURATION_TYPES})
+                if(NOT TYPE STREQUAL "MinSizeRel" AND NOT TYPE STREQUAL "RelWithDebInfo")
+                    run_conan_install(${TYPE})
+                endif()
+            endforeach()
+        else()
+            if(NOT CMAKE_BUILD_TYPE)
+                set(CMAKE_BUILD_TYPE Release)
+            endif()
+            run_conan_install(${CMAKE_BUILD_TYPE})
+        endif()
+
+        list(APPEND CMAKE_PREFIX_PATH "${CMAKE_BINARY_DIR}")
+    endif()
+endif()
+
 # Global settings
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -32,6 +104,10 @@ CPMAddPackage(
         "BUILD_GAMES OFF"
 )
 
+if(TARGET raylib::raylib AND NOT TARGET raylib)
+    add_library(raylib ALIAS raylib::raylib)
+endif()
+
 CPMAddPackage(
     NAME glm
     GITHUB_REPOSITORY g-truc/glm
@@ -39,6 +115,14 @@ CPMAddPackage(
     OPTIONS
         "GLM_BUILD_TESTS OFF"
 )
+
+if(TARGET glm::glm AND NOT TARGET glm)
+    add_library(glm ALIAS glm::glm)
+endif()
+
+if(CPM_USE_LOCAL_PACKAGES)
+    find_package(lua QUIET)
+endif()
 
 CPMAddPackage(
     NAME lua
@@ -89,6 +173,8 @@ if(lua_ADDED)
     if(UNIX AND NOT APPLE)
         target_link_libraries(lua m dl)
     endif()
+elseif(TARGET lua::lua AND NOT TARGET lua)
+    add_library(lua ALIAS lua::lua)
 endif()
 
 add_compile_definitions(SOL_ALL_SAFETIES_ON)
@@ -98,6 +184,10 @@ CPMAddPackage(
     GITHUB_REPOSITORY ThePhD/sol2
     GIT_TAG v3.5.0
 )
+
+if(TARGET sol2::sol2 AND NOT TARGET sol2)
+    add_library(sol2 ALIAS sol2::sol2)
+endif()
 
 # Use standalone Asio instead of full Boost
 CPMAddPackage(
@@ -111,7 +201,7 @@ if(asio_ADDED)
     add_library(asio INTERFACE)
     target_include_directories(asio INTERFACE ${asio_SOURCE_DIR}/asio/include)
     target_compile_definitions(asio INTERFACE ASIO_STANDALONE)
-    
+
     # Windows-specific settings
     if(WIN32)
         target_compile_definitions(asio INTERFACE 
@@ -124,16 +214,30 @@ if(asio_ADDED)
     
     find_package(Threads REQUIRED)
     target_link_libraries(asio INTERFACE Threads::Threads)
+elseif(TARGET asio::asio AND NOT TARGET asio)
+    add_library(asio ALIAS asio::asio)
 endif()
 
 # cpp-httplib for HTTP client requests to Node backend
+if(CPM_USE_LOCAL_PACKAGES)
+    find_package(httplib QUIET)
+    if(httplib_FOUND AND NOT TARGET cpp-httplib::cpp-httplib)
+        add_library(cpp-httplib::cpp-httplib ALIAS httplib::httplib)
+    endif()
+endif()
+
 CPMAddPackage(
     NAME cpp-httplib
     GITHUB_REPOSITORY yhirose/cpp-httplib
     GIT_TAG v0.15.3
     DOWNLOAD_ONLY YES
 )
-set(CPP_HTTPLIB_INCLUDE_DIR ${cpp-httplib_SOURCE_DIR})
+
+if(cpp-httplib_ADDED)
+    set(CPP_HTTPLIB_INCLUDE_DIR ${cpp-httplib_SOURCE_DIR})
+elseif(TARGET cpp-httplib::cpp-httplib)
+    get_target_property(CPP_HTTPLIB_INCLUDE_DIR cpp-httplib::cpp-httplib INTERFACE_INCLUDE_DIRECTORIES)
+endif()
 
 # nlohmann/json for JSON serialization
 CPMAddPackage(
@@ -150,6 +254,11 @@ CPMAddPackage(
         "BOOST_ENABLE_CMAKE ON"
         "BOOST_INCLUDE_LIBRARIES interprocess;system;filesystem;date_time"
 )
+
+# Fix for Conan Boost targets
+if(TARGET Boost::boost AND NOT TARGET Boost::interprocess)
+    add_library(Boost::interprocess ALIAS Boost::boost)
+endif()
 
 # Only for Debug builds
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,0 +1,16 @@
+[requires]
+raylib/5.5
+glm/1.0.1
+lua/5.4.6
+sol2/3.5.0
+asio/1.30.2
+cpp-httplib/0.15.3
+nlohmann_json/3.11.3
+boost/1.84.0
+
+[generators]
+CMakeDeps
+CMakeToolchain
+
+[layout]
+cmake_layout


### PR DESCRIPTION
## Summary
This PR adds Conan as a secondary packet manager if CPM is down

## Related Issue(s)
#140 



<!-- ########## FEATURE PULL REQUEST ##########-->
## Additions
- add Conan as secondary PKG manager

## Testing
1. clear your build and .cache folder :D
2. try `cmake -B build -DUSE_CONAN=ON .`

## Checklist
- [x] Source branch is based on `dev`
- [x] Linked to the correct GitHub issues
- [x] Added at least 2 people as reviewers, 4 if you are merging into main
- [x] No conflicts
- [x] Documentation deployment CI must pass
